### PR TITLE
ssl-expiry-reminder and Install Gotify on Apache

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Here you'll find community contributions to the Gotify project.
 - [caronc/apprise](https://github.com/caronc/apprise) A notification library for almost all popular notification services.
 - [denisgolius/zabbix-to-gotify-alert](https://github.com/denisgolius/zabbix-to-gotify-alert) A guide for sending alerts from [Zabbix](https://www.zabbix.com/) to `gotify/server`.
 - [marceltransier/gotify-slack](https://github.com/marceltransier/gotify-slack) A Plugin for Slack push notifications.
-- [mskian/ssl-expiry-reminder](https://github.com/mskian/ssl-expiry-reminder) SSL Expiry Reminde -  Get SSL Expiry Notification remainder Alerts on `gotify/server`.
+- [mskian/ssl-expiry-reminder](https://github.com/mskian/ssl-expiry-reminder) SSL Expiry Reminder -  Get SSL Expiry Notification remainder Alerts on `gotify/server`.
 - [mskian/gotify-apache](https://github.com/mskian/gotify-apache) Install and Configure Gotify without Docker in Apache Server.
 - [no-go/NotifyRelay](https://github.com/no-go/NotifyRelay) An Android app for relaying almost all Android messages to `gotify/server`. [F-Droid](https://f-droid.org/packages/click.dummer.notify_to_jabber/)
 - [ppacher/moziot-gotify-addon](https://github.com/ppacher/moziot-gotify-addon) A Mozilla WoT gateway addon to send notifications via `gotify`.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Here you'll find community contributions to the Gotify project.
 - [caronc/apprise](https://github.com/caronc/apprise) A notification library for almost all popular notification services.
 - [denisgolius/zabbix-to-gotify-alert](https://github.com/denisgolius/zabbix-to-gotify-alert) A guide for sending alerts from [Zabbix](https://www.zabbix.com/) to `gotify/server`.
 - [marceltransier/gotify-slack](https://github.com/marceltransier/gotify-slack) A Plugin for Slack push notifications.
+- [mskian/ssl-expiry-reminder](https://github.com/mskian/ssl-expiry-reminder) SSL Expiry Reminde -  Get SSL Expiry Notification remainder Alerts on `gotify/server`.
+- [mskian/gotify-apache](https://github.com/mskian/gotify-apache) Install and Configure Gotify without Docker in Apache Server.
 - [no-go/NotifyRelay](https://github.com/no-go/NotifyRelay) An Android app for relaying almost all Android messages to `gotify/server`. [F-Droid](https://f-droid.org/packages/click.dummer.notify_to_jabber/)
 - [ppacher/moziot-gotify-addon](https://github.com/ppacher/moziot-gotify-addon) A Mozilla WoT gateway addon to send notifications via `gotify`.
 - [render-examples/gotify-server](https://github.com/render-examples/gotify-server) A guide to deploying `gotify/server` on [Render](https://render.com).


### PR DESCRIPTION
- SSL Expiry Reminder -  Get SSL Expiry Notification remainder Alerts on `gotify/server`
- Install and Configure Gotify without Docker in Apache Server
