### PR TITLE
Add Gotify-Ext

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,4 @@ Here you'll find community contributions to the Gotify project.
 - [ppacher/moziot-gotify-addon](https://github.com/ppacher/moziot-gotify-addon) A Mozilla WoT gateway addon to send notifications via `gotify`.
 - [rorpage/gotify-chrome](https://github.com/rorpage/gotify-chrome) A Chrome extension for sending messages to `gotify/server`.
 - [schwma/gotify-push](https://github.com/schwma/gotify-push) A Python CLI for sending messages to `gotify/server`.
+- [StewartThomson/Gotify-Ext](https://github.com/StewartThomson/Gotify-Ext) A Browser extension for viewing and managing gotify servers


### PR DESCRIPTION
Hi, I've created a gotify chrome extension for viewing and managing gotify server(s). It's available at https://chrome.google.com/webstore/detail/gotify/defcailckfpgaigaiijligpnjipkhhmg

- [x] Your submissions have the following format:
    ```
    - [StewartThomson/Gotify-Ext](https://github.com/StewartThomson/Gotify-Ext) A Browser extension for viewing and managing gotify servers
    ```
- [x] Your additions are ordered alphabetically.
- [x] The projects you add are actively maintained.
