### PR TITLE
Add plugin tystuyfzand/gotify-mqtt

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Here you'll find community contributions to the Gotify project.
 
 - [eternal-flame-AD/gotify-broadcast](https://github.com/eternal-flame-AD/gotify-broadcast) A plugin for message broadcasts to multiple users.
 - [marceltransier/gotify-slack](https://github.com/marceltransier/gotify-slack) A plugin for Slack push notifications.
+- [tystuyfzand/gotify-mqtt](https://github.com/tystuyfzand/gotify-mqtt) A plugin for MQTT message subscriptions (for IoT and others).
 - [tystuyfzand/gotify-smtp](https://github.com/tystuyfzand/gotify-smtp) A plugin for SMTP ingest of notifications.
 
 ## Tools / Applications


### PR DESCRIPTION
Another plugin for #11 - this time implementing MQTT so that messages can be pulled into Gotify via a message broker server.