### PR TITLE
Link to the correct repo for VerifiedJoseph/gotify-api-php

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Here you'll find community contributions to the Gotify project.
 
 - [ajmcateer/GotifySharp](https://github.com/ajmcateer/GotifySharp) A C# library for interacting with `gotify/server`.
 - [caronc/apprise](https://github.com/caronc/apprise) A notification library for almost all popular notification services.
-- [VerifiedJoseph/gotify-api-php](https://github.com/caronc/apprise) A PHP library for interacting with `gotify/server`.
+- [VerifiedJoseph/gotify-api-php](https://github.com/VerifiedJoseph/gotify-api-php) A PHP library for interacting with `gotify/server`.
 
 ## Plugins
 


### PR DESCRIPTION
Fixes my mistake in #30. I forgot to change the link to `https://github.com/VerifiedJoseph/gotify-api-php`