### PR TITLE
added gigigig/bedrock-docker-gotify

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Here you'll find community contributions to the Gotify project.
 - [diddypod/rotify](https://github.com/diddypod/rotify) Send and view Gotify messages via [rofi](https://github.com/davatorium/rofi).
 - [eikendev/action-gotify](https://github.com/eikendev/action-gotify) A GitHub action to send notifications via `gotify/server`.
 - [Enchufadoo/gotify-fox](https://github.com/Enchufadoo/gotify-fox) A Firefox addon for sending messages to `gotify/server`.
+- [gigigig/bedrock-docker-gotify](https://github.com/gigigig/bedrock-docker-gotify) Sends Player Events from Minecraft Bedrock Docker Server to `gotify/server`.
 - [immanuelfodor/rocketchat-push-gateway](https://github.com/immanuelfodor/rocketchat-push-gateway) A push gateway for RocketChat to send notifications to `gotify/server`.
 - [kha7iq/pingme](https://github.com/kha7iq/pingme) A CLI tool which provides the ability to send messages to multiple messaging platforms.
 - [mattmckenzy/mail2gotify](https://github.com/MattMckenzy/Mail2Gotify) A stand-alone, hosted SMTP server that relays email notifications to `gotify/server`.


### PR DESCRIPTION
- [x] Your submissions have the following format:
    ```
    - [gigigig/bedrock-docker-gotify](https://github.com/gigigig/bedrock-docker-gotify) Sends Player Events from Minecraft Bedrock Docker Server to `gotify/server`.
    ```
- [x] Your additions are ordered alphabetically.
- [x] The projects you add are actively maintained.
