### PR TITLE
Add Winify as Windows (7+) desktop client.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,5 +57,5 @@ Here you'll find community contributions to the Gotify project.
 - [schwma/gotify-push](https://github.com/schwma/gotify-push) A Python CLI for sending messages to `gotify/server`.
 - [sebw/pushtify](https://github.com/sebw/pushtify) Forward Gotify notifications to Pushover.
 - [StewartThomson/Gotify-Ext](https://github.com/StewartThomson/Gotify-Ext) A Browser extension for viewing and managing gotify servers
+- [Winify](https://winify.grimore.org/) A Windows (7+) desktop client for receiving notifications from Gotify.
 - [ztpnk/gotify-dunst](https://github.com/ztpnk/gotify-dunst) A gotify client for your Linux Desktop
-- [Winify](https://grimore.org/windows/winify) A Windows (7+) desktop client for receiving notifications from Gotify.

--- a/README.md
+++ b/README.md
@@ -58,3 +58,4 @@ Here you'll find community contributions to the Gotify project.
 - [sebw/pushtify](https://github.com/sebw/pushtify) Forward Gotify notifications to Pushover.
 - [StewartThomson/Gotify-Ext](https://github.com/StewartThomson/Gotify-Ext) A Browser extension for viewing and managing gotify servers
 - [ztpnk/gotify-dunst](https://github.com/ztpnk/gotify-dunst) A gotify client for your Linux Desktop
+- [Winify](https://grimore.org/windows/winify) A Windows (7+) desktop client for receiving notifications from Gotify.


### PR DESCRIPTION
Hello! I would like to add Winify as a Windows (7+) desktop client for Gotify. The project is under active development, maintained and has ample documentation. Please add. Thanks!
