### PR TITLE
Add gotify-commander to Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Here you'll find community contributions to the Gotify project.
 - [Barina/gotify-webhookah](https://github.com/Barina/gotify-webhookah) Webhook builder with extra capabilities (like messages with markdown support, domain override, etc).
 - [ckocyigit/gotify-authentik-plugin](https://github.com/ckocyigit/gotify-authentik-plugin) A plugin that allows gotify/server to directly receive and process webhooks from [Authentik](https://github.com/goauthentik/authentik). 
 - [david-kalmakoff/gotify-smtp-emailer](https://github.com/david-kalmakoff/gotify-smtp-emailer) A plugin for forwarding received messages to email through SMTP
+- [drolosoft/gotify-commander](https://github.com/drolosoft/gotify-commander) A bidirectional plugin that executes server commands from Gotify messages — restart services, check system health, view logs — and sends results back as notifications. Includes a web-based control panel.
 - [elgonlabs/gotify-emailer](https://github.com/elgonlabs/gotify-emailer) A plugin for sending emails for incoming gotify/server messages.
 - [eternal-flame-AD/gotify-broadcast](https://github.com/eternal-flame-AD/gotify-broadcast) A plugin for message broadcasts to multiple users.
 - [eternal-flame-AD/gotify-webhook-misskey](https://github.com/eternal-flame-AD/gotify-webhook-misskey) A plugin for receiving notification from federated social networking platform [Misskey](https://github.com/misskey-dev/misskey) with multi-user support.


### PR DESCRIPTION
Add [gotify-commander](https://github.com/drolosoft/gotify-commander) to the Plugins section.

**What it does:** A bidirectional Gotify plugin — the first that lets users send commands back. Type `restart nginx` from the Gotify app, get ✅ nginx restarted as a notification.

- 23 commands: service management, system diagnostics, traffic analytics, GPS locate
- Web-based control panel served from the plugin's webhook endpoint
- Multi-machine: local (systemctl) + remote (SSH/launchctl)
- Config-driven: YAML defines services, categories, and behavior
- Security: whitelisted commands, input sanitization, execution timeouts
- MIT license, Go, works with Gotify 2.6.x
- Pre-built .so for linux/amd64

[GitHub](https://github.com/drolosoft/gotify-commander) · [Release v0.2.0](https://github.com/drolosoft/gotify-commander/releases/tag/v0.2.0)